### PR TITLE
#255 Adds issue template for bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
# What changes were made?
- A new folder inside `.github/` was created named `ISSUE_TEMPLATE` which is meant to store all the issues template by default.
- A new file `.github/ISSUE_TEMPLATE/bug_report.md` was created which holds the content of the issue template `Bug report`.

# Description of the changes made
Now, a new issue template has been created for Bug Report which does following things automatically,
- Any issue  creator will get a well-defined structure for reporting the bug,
- Automatically, when the issue is created, `bug` label would be labelled to the issue and a placeholder as `[BUG]` will be provided to the issue creator while creating a new issue. 