### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Markdown lint
 
 on: [push]


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/AcademicContent/security/code-scanning/5](https://github.com/microsoft/AcademicContent/security/code-scanning/5)

To fix the problem, explicitly set the `permissions` block in the workflow file to restrict the `GITHUB_TOKEN` to the least privilege required. Since this workflow only runs a linter and does not need to write to the repository or interact with issues or pull requests, the minimal required permission is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level. The best practice is to add the following at the top level of the workflow file, just after the `name` field and before `on`, to ensure all jobs inherit these minimal permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
