### PR TITLE
Potential fix for code scanning alert no. 13: Double escaping or unescaping

### DIFF
--- a/archive/Educator Resources/Course Content/Module2/code/lesson2/escape.js
+++ b/archive/Educator Resources/Course Content/Module2/code/lesson2/escape.js
@@ -24,11 +24,11 @@ module.exports = function(ops){
 
   unescape: function(html) {
     return String(html)
-      .replace(/&amp;/g, '&')
       .replace(/&quot;/g, '"')
       .replace(/&#39;/g, "'")
       .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>');
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&');
   }
  }
 };


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/AcademicContent/security/code-scanning/13](https://github.com/microsoft/AcademicContent/security/code-scanning/13)

To fix the double-unescaping problem, the order of replacements in the `unescape` function should be changed so that the ampersand (`&amp;`) is unescaped last. This ensures that any other entities (like `&quot;`, `&#39;`, etc.) are unescaped before the ampersand, preventing the accidental creation of new entities that would then be unescaped again. The fix involves moving the `.replace(/&amp;/g, '&')` call to the end of the chain in the `unescape` function. No new imports or dependencies are needed, and the change is limited to the `unescape` method in the shown file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
