### PR TITLE
Potential fix for code scanning alert no. 7: Failure to use secure cookies

### DIFF
--- a/archive/Events and Hacks/Tech Talks/ContainerDemo/example-voting-app/vote/app.py
+++ b/archive/Events and Hacks/Tech Talks/ContainerDemo/example-voting-app/vote/app.py
@@ -38,7 +38,7 @@ def hello():
         hostname=hostname,
         vote=vote,
     ))
-    resp.set_cookie('voter_id', voter_id)
+    resp.set_cookie('voter_id', voter_id, secure=True, httponly=True, samesite='Lax')
     return resp
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/AcademicContent/security/code-scanning/7](https://github.com/microsoft/AcademicContent/security/code-scanning/7)

To fix the problem, the `set_cookie` call on line 41 should explicitly set the `secure`, `httponly`, and `samesite` attributes to secure values. Specifically, set `secure=True` (so the cookie is only sent over HTTPS), `httponly=True` (so the cookie is not accessible to JavaScript), and `samesite='Lax'` (so the cookie is not sent with most cross-site requests, mitigating CSRF). This change should be made directly in the `resp.set_cookie` call in the `hello` function in `archive/Events and Hacks/Tech Talks/ContainerDemo/example-voting-app/vote/app.py`. No new imports or additional code are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
