### PR TITLE
Potential fix for code scanning alert no. 16: Reflected cross-site scripting

### DIFF
--- a/archive/Educator Resources/Course Content/Module2/code/lesson5/lab2/app.js
+++ b/archive/Educator Resources/Course Content/Module2/code/lesson5/lab2/app.js
@@ -1,6 +1,7 @@
 var express = require('express'),
   bodyParser = require('body-parser'),
-  logger = require('morgan')
+  logger = require('morgan'),
+  escapeHtml = require('escape-html')
 
 let posts = require('./posts.json')
 
@@ -15,7 +16,17 @@ app.get('/', function(req, res, next) {
 })
 
 app.get('/api/posts', function(req, res, next) {
-  let results = posts
+  let results = posts.map(post => {
+    let escapedPost = {};
+    for (let key in post) {
+      if (typeof post[key] === 'string') {
+        escapedPost[key] = escapeHtml(post[key]);
+      } else {
+        escapedPost[key] = post[key];
+      }
+    }
+    return escapedPost;
+  });
   res.send(results)
 })
 

--- a/archive/Educator Resources/Course Content/Module2/code/lesson5/lab2/package.json
+++ b/archive/Educator Resources/Course Content/Module2/code/lesson5/lab2/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "body-parser": ">=1.20.3",
     "express": ">=4.20.0",
-    "morgan": "1.9.1"
+    "morgan": "1.9.1",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "body-parser": ">=1.20.3",


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/AcademicContent/security/code-scanning/16](https://github.com/microsoft/AcademicContent/security/code-scanning/16)

To fix the reflected XSS vulnerability, we should ensure that any user-provided data is properly sanitized before being stored or returned in API responses. Since the `/api/posts` endpoint returns all posts, including those created by users, we should escape any potentially dangerous content before sending it in the response. The best way to do this is to encode/escape all string fields in each post before sending the response. We can use a well-known library such as `escape-html` to escape HTML special characters in string fields. This can be done by mapping over the `posts` array and escaping all string fields in each post before sending the response in the `/api/posts` GET handler.

**Required changes:**
- Add the `escape-html` import at the top of the file.
- In the `/api/posts` GET handler, map over the `posts` array and escape all string fields in each post before sending the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
